### PR TITLE
test: add DataMint pytest fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ tab = TabularGenerator(seed=42)
 rows = tab.generate(schema=schema, count=100)
 ```
 
+## Pytest Fixtures
+
+DataMint exposes a pytest plugin with deterministic fixtures for test suites:
+
+```python
+def test_rag_pipeline(synthetic_qa_dataset, adversarial_prompts):
+    assert synthetic_qa_dataset[0].question
+    assert adversarial_prompts[0].text
+```
+
+Available fixtures:
+
+- `synthetic_qa_dataset` -- five deterministic `QAPair` objects
+- `adversarial_prompts` -- five deterministic `AdversarialPrompt` objects
+
 ## Adversarial Categories
 
 | Category | Templates | Example |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dev = [
 [project.scripts]
 datamint = "datamint.cli:main"
 
+[project.entry-points.pytest11]
+datamint = "datamint.pytest_plugin"
+
 [project.urls]
 Homepage = "https://github.com/YOUR_ORG/datamint"
 Documentation = "https://github.com/YOUR_ORG/datamint/tree/main/docs"

--- a/src/datamint/pytest_plugin.py
+++ b/src/datamint/pytest_plugin.py
@@ -1,0 +1,20 @@
+"""Pytest fixtures for DataMint-generated test data."""
+
+from __future__ import annotations
+
+import pytest
+
+from datamint.core import AdversarialGenerator, AdversarialPrompt, QAGenerator, QAPair
+
+
+@pytest.fixture
+def synthetic_qa_dataset() -> list[QAPair]:
+    """Return a deterministic small QA dataset for tests."""
+    return QAGenerator(seed=42).generate(count=5)
+
+
+@pytest.fixture
+def adversarial_prompts() -> list[AdversarialPrompt]:
+    """Return deterministic adversarial prompts for red-team tests."""
+    return AdversarialGenerator(seed=42).generate(count=5)
+

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,18 @@
+"""Tests for the DataMint pytest fixtures."""
+
+from __future__ import annotations
+
+from datamint.core import AdversarialPrompt, QAPair
+
+
+def test_synthetic_qa_dataset_fixture(synthetic_qa_dataset: list[QAPair]) -> None:
+    assert len(synthetic_qa_dataset) == 5
+    assert all(isinstance(pair, QAPair) for pair in synthetic_qa_dataset)
+    assert all(pair.question and pair.answer for pair in synthetic_qa_dataset)
+
+
+def test_adversarial_prompts_fixture(adversarial_prompts: list[AdversarialPrompt]) -> None:
+    assert len(adversarial_prompts) == 5
+    assert all(isinstance(prompt, AdversarialPrompt) for prompt in adversarial_prompts)
+    assert all(prompt.text for prompt in adversarial_prompts)
+


### PR DESCRIPTION
Fixes #2

## Summary
- Added a `datamint.pytest_plugin` module with `synthetic_qa_dataset` and `adversarial_prompts` fixtures.
- Registered the plugin via the `pytest11` entry point so pytest can auto-load the fixtures when DataMint is installed in a test environment.
- Added tests that exercise both fixtures and documented usage in the README.

## Tests
- `uv run --extra dev pytest tests/test_pytest_plugin.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --extra dev ruff check src/datamint/pytest_plugin.py tests/test_pytest_plugin.py`
- `git diff --check`

## Notes
- `uv run --python 3.12 --extra dev ruff check src/ tests/` still reports pre-existing lint issues in `src/datamint/core.py`, `tests/test_core.py`, and `tests/test_integration.py`; I kept this PR focused on the new plugin files.
